### PR TITLE
[BEAM-2660] Set PubsubIO batch size using builder

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -497,7 +497,9 @@ public class PubsubIO {
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
   private static <T> Write<T> write() {
-    return new AutoValue_PubsubIO_Write.Builder<T>().build();
+    return new org.apache.beam.sdk.io.gcp.pubsub.AutoValue_PubsubIO_Write.Builder<T>()
+            .setBatchSize(100)
+            .build();
   }
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
@@ -762,6 +764,9 @@ public class PubsubIO {
     @Nullable
     abstract ValueProvider<PubsubTopic> getTopicProvider();
 
+    /** the batch size for bulk submissions to pubsub. */
+    abstract int getBatchSize();
+
     /** The name of the message attribute to publish message timestamps in. */
     @Nullable
     abstract String getTimestampAttribute();
@@ -779,6 +784,8 @@ public class PubsubIO {
     @AutoValue.Builder
     abstract static class Builder<T> {
       abstract Builder<T> setTopicProvider(ValueProvider<PubsubTopic> topicProvider);
+
+      abstract Builder<T> setBatchSize(int batchSize);
 
       abstract Builder<T> setTimestampAttribute(String timestampAttribute);
 
@@ -806,6 +813,21 @@ public class PubsubIO {
       return toBuilder()
           .setTopicProvider(NestedValueProvider.of(topic, new TopicTranslator()))
           .build();
+    }
+
+    /**
+     * Writes to Pub/Sub are batched to efficiently send data. The value of the attribute will
+     * be a number representing the number of Pub/Sub messages to queue before sending off the
+     * bulk request. For example, if given 1000 the write sink will wait until 1000 messages have
+     * been received, or the pipeline has finished, whichever is first.
+     *
+     * <p>Pub/Sub has a limitation of 10mb per individual request/batch. This attribute was
+     * requested dynamic to allow larger Pub/Sub messages to be sent using this source. Thus
+     * allowing customizable batches and control of number of events before the 10mb size limit
+     * is hit.
+     */
+    public Write<T> withBatchSize(int batchSize) {
+      return toBuilder().setBatchSize(batchSize).build();
     }
 
     /**
@@ -882,12 +904,13 @@ public class PubsubIO {
      */
     public class PubsubBoundedWriter extends DoFn<T, Void> {
 
-      private static final int MAX_PUBLISH_BATCH_SIZE = 100;
       private transient List<OutgoingMessage> output;
       private transient PubsubClient pubsubClient;
+      private int maxPublishBatchSize;
 
       @StartBundle
       public void startBundle(StartBundleContext c) throws IOException {
+        this.maxPublishBatchSize = getBatchSize();
         this.output = new ArrayList<>();
         // NOTE: idAttribute is ignored.
         this.pubsubClient =
@@ -904,7 +927,7 @@ public class PubsubIO {
         // NOTE: The record id is always null.
         output.add(new OutgoingMessage(payload, attributes, c.timestamp().getMillis(), null));
 
-        if (output.size() >= MAX_PUBLISH_BATCH_SIZE) {
+        if (output.size() >= maxPublishBatchSize) {
           publish();
         }
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import javax.naming.SizeLimitExceededException;
+
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
@@ -498,7 +500,8 @@ public class PubsubIO {
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
   private static <T> Write<T> write() {
     return new org.apache.beam.sdk.io.gcp.pubsub.AutoValue_PubsubIO_Write.Builder<T>()
-            .setBatchSize(100)
+            .setBatchSize(1000)
+            .setMaxBatchBytesSize(1000000)
             .build();
   }
 
@@ -767,6 +770,9 @@ public class PubsubIO {
     /** the batch size for bulk submissions to pubsub. */
     abstract int getBatchSize();
 
+    /** the maximum batch size, by bytes. */
+    abstract int getMaxBatchBytesSize();
+
     /** The name of the message attribute to publish message timestamps in. */
     @Nullable
     abstract String getTimestampAttribute();
@@ -786,6 +792,8 @@ public class PubsubIO {
       abstract Builder<T> setTopicProvider(ValueProvider<PubsubTopic> topicProvider);
 
       abstract Builder<T> setBatchSize(int batchSize);
+
+      abstract Builder<T> setMaxBatchBytesSize(int maxBatchBytesSize);
 
       abstract Builder<T> setTimestampAttribute(String timestampAttribute);
 
@@ -828,6 +836,14 @@ public class PubsubIO {
      */
     public Write<T> withBatchSize(int batchSize) {
       return toBuilder().setBatchSize(batchSize).build();
+    }
+
+    /**
+     * Writes to Pub/Sub are limited by 10mb in general. This attribute controls the maximum allowed
+     * bytes to be sent to Pub/Sub in a single batched message.
+     */
+    public Write<T> withMaxBatchBytesSize(int maxBatchBytesSize) {
+      return toBuilder().setMaxBatchBytesSize(maxBatchBytesSize).build();
     }
 
     /**
@@ -906,12 +922,18 @@ public class PubsubIO {
 
       private transient List<OutgoingMessage> output;
       private transient PubsubClient pubsubClient;
+      private transient int currentOutputBytes;
+
+      private int maxPublishBatchByteSize;
       private int maxPublishBatchSize;
 
       @StartBundle
       public void startBundle(StartBundleContext c) throws IOException {
+        this.maxPublishBatchByteSize = getMaxBatchBytesSize();
         this.maxPublishBatchSize = getBatchSize();
         this.output = new ArrayList<>();
+        this.currentOutputBytes = 0;
+
         // NOTE: idAttribute is ignored.
         this.pubsubClient =
             FACTORY.newClient(getTimestampAttribute(), null,
@@ -919,17 +941,27 @@ public class PubsubIO {
       }
 
       @ProcessElement
-      public void processElement(ProcessContext c) throws IOException {
+      public void processElement(ProcessContext c) throws IOException, SizeLimitExceededException {
         byte[] payload;
         PubsubMessage message = getFormatFn().apply(c.element());
         payload = message.getPayload();
         Map<String, String> attributes = message.getAttributeMap();
-        // NOTE: The record id is always null.
-        output.add(new OutgoingMessage(payload, attributes, c.timestamp().getMillis(), null));
 
-        if (output.size() >= maxPublishBatchSize) {
+        if (payload.length > maxPublishBatchByteSize) {
+          String msg = String.format("Pub/Sub message size (%d) exceeded maximum batch size (%d)",
+                  payload.length, maxPublishBatchByteSize);
+          throw new SizeLimitExceededException(msg);
+        }
+
+        // Checking before adding the message stops us from violating the max bytes
+        if (((currentOutputBytes + payload.length) >= maxPublishBatchByteSize)
+                || (output.size() >= maxPublishBatchSize)) {
           publish();
         }
+
+        // NOTE: The record id is always null.
+        output.add(new OutgoingMessage(payload, attributes, c.timestamp().getMillis(), null));
+        currentOutputBytes += payload.length;
       }
 
       @FinishBundle
@@ -938,6 +970,7 @@ public class PubsubIO {
           publish();
         }
         output = null;
+        currentOutputBytes = 0;
         pubsubClient.close();
         pubsubClient = null;
       }
@@ -951,6 +984,7 @@ public class PubsubIO {
                 output);
         checkState(n == output.size());
         output.clear();
+        currentOutputBytes = 0;
       }
 
       @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.pubsub;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import java.io.IOException;
@@ -499,10 +500,7 @@ public class PubsubIO {
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
   private static <T> Write<T> write() {
-    return new org.apache.beam.sdk.io.gcp.pubsub.AutoValue_PubsubIO_Write.Builder<T>()
-            .setBatchSize(1000)
-            .setMaxBatchBytesSize(1000000)
-            .build();
+    return new AutoValue_PubsubIO_Write.Builder<T>().build();
   }
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
@@ -764,14 +762,19 @@ public class PubsubIO {
   /** Implementation of {@link #write}. */
   @AutoValue
   public abstract static class Write<T> extends PTransform<PCollection<T>, PDone> {
+    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = 1000000;
+    private static final int MAX_PUBLISH_BATCH_SIZE = 100;
+
     @Nullable
     abstract ValueProvider<PubsubTopic> getTopicProvider();
 
     /** the batch size for bulk submissions to pubsub. */
-    abstract int getBatchSize();
+    @Nullable
+    abstract Integer getMaxBatchSize();
 
     /** the maximum batch size, by bytes. */
-    abstract int getMaxBatchBytesSize();
+    @Nullable
+    abstract Integer getMaxBatchBytesSize();
 
     /** The name of the message attribute to publish message timestamps in. */
     @Nullable
@@ -791,9 +794,9 @@ public class PubsubIO {
     abstract static class Builder<T> {
       abstract Builder<T> setTopicProvider(ValueProvider<PubsubTopic> topicProvider);
 
-      abstract Builder<T> setBatchSize(int batchSize);
+      abstract Builder<T> setMaxBatchSize(Integer batchSize);
 
-      abstract Builder<T> setMaxBatchBytesSize(int maxBatchBytesSize);
+      abstract Builder<T> setMaxBatchBytesSize(Integer maxBatchBytesSize);
 
       abstract Builder<T> setTimestampAttribute(String timestampAttribute);
 
@@ -834,8 +837,8 @@ public class PubsubIO {
      * allowing customizable batches and control of number of events before the 10mb size limit
      * is hit.
      */
-    public Write<T> withBatchSize(int batchSize) {
-      return toBuilder().setBatchSize(batchSize).build();
+    public Write<T> withMaxBatchSize(int batchSize) {
+      return toBuilder().setMaxBatchSize(batchSize).build();
     }
 
     /**
@@ -886,9 +889,15 @@ public class PubsubIO {
       if (getTopicProvider() == null) {
         throw new IllegalStateException("need to set the topic of a PubsubIO.Write transform");
       }
+
       switch (input.isBounded()) {
         case BOUNDED:
-          input.apply(ParDo.of(new PubsubBoundedWriter()));
+          input.apply(ParDo.of(new PubsubBoundedWriter(
+              MoreObjects.firstNonNull(getMaxBatchSize(),
+                      MAX_PUBLISH_BATCH_SIZE),
+              MoreObjects.firstNonNull(getMaxBatchBytesSize(),
+                      MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT)
+          )));
           return PDone.in(input.getPipeline());
         case UNBOUNDED:
           return input.apply(MapElements.via(getFormatFn())).apply(new PubsubUnboundedSink(
@@ -896,7 +905,12 @@ public class PubsubIO {
               NestedValueProvider.of(getTopicProvider(), new TopicPathTranslator()),
               getTimestampAttribute(),
               getIdAttribute(),
-              100 /* numShards */));
+              100,
+              MoreObjects.firstNonNull(getMaxBatchSize(),
+                      PubsubUnboundedSink.DEFAULT_PUBLISH_BATCH_SIZE),
+              MoreObjects.firstNonNull(getMaxBatchBytesSize(),
+                      PubsubUnboundedSink.DEFAULT_PUBLISH_BATCH_BYTES)
+          ));
       }
       throw new RuntimeException(); // cases are exhaustive.
     }
@@ -919,7 +933,6 @@ public class PubsubIO {
      * <p>Public so can be suppressed by runners.
      */
     public class PubsubBoundedWriter extends DoFn<T, Void> {
-
       private transient List<OutgoingMessage> output;
       private transient PubsubClient pubsubClient;
       private transient int currentOutputBytes;
@@ -927,10 +940,17 @@ public class PubsubIO {
       private int maxPublishBatchByteSize;
       private int maxPublishBatchSize;
 
+      PubsubBoundedWriter(int maxPublishBatchSize, int maxPublishBatchByteSize) {
+        this.maxPublishBatchSize = maxPublishBatchSize;
+        this.maxPublishBatchByteSize = maxPublishBatchByteSize;
+      }
+
+      PubsubBoundedWriter() {
+        this(MAX_PUBLISH_BATCH_SIZE, MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT);
+      }
+
       @StartBundle
       public void startBundle(StartBundleContext c) throws IOException {
-        this.maxPublishBatchByteSize = getMaxBatchBytesSize();
-        this.maxPublishBatchSize = getBatchSize();
         this.output = new ArrayList<>();
         this.currentOutputBytes = 0;
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
@@ -85,12 +85,12 @@ public class PubsubUnboundedSink extends PTransform<PCollection<PubsubMessage>, 
   /**
    * Default maximum number of messages per publish.
    */
-  private static final int DEFAULT_PUBLISH_BATCH_SIZE = 1000;
+  static final int DEFAULT_PUBLISH_BATCH_SIZE = 1000;
 
   /**
    * Default maximum size of a publish batch, in bytes.
    */
-  private static final int DEFAULT_PUBLISH_BATCH_BYTES = 400000;
+  static final int DEFAULT_PUBLISH_BATCH_BYTES = 400000;
 
   /**
    * Default longest delay between receiving a message and pushing it to Pubsub.
@@ -396,6 +396,18 @@ public class PubsubUnboundedSink extends PTransform<PCollection<PubsubMessage>, 
          RecordIdMethod.RANDOM);
   }
 
+  public PubsubUnboundedSink(
+          PubsubClientFactory pubsubFactory,
+          ValueProvider<TopicPath> topic,
+          String timestampAttribute,
+          String idAttribute,
+          int numShards,
+          int publishBatchSize,
+          int publishBatchBytes) {
+    this(pubsubFactory, topic, timestampAttribute, idAttribute, numShards,
+            publishBatchSize, publishBatchBytes, DEFAULT_MAX_LATENCY,
+            RecordIdMethod.RANDOM);
+  }
   /**
    * Get the topic being written to.
    */


### PR DESCRIPTION
BEAM-2660 asks for controlling batch size using the `PubsubIO.Write.Builder`

This PR adds Two values configurable through the `PubsubIO.Write.Builder`:
- `maxBatchSize` - controls the bulk batch request size
- `maxBatchByteSize` - controls the bulk batch bytes request size

In this PR I have also made a modification to the `PubsubIO.Write.PubsubBoundedWriter`. Now the writer will dynamically track the number of bytes allocated for all messages. If the number of bytes exceeds the threshold it will publish before adding more messages.

If the message size exceeds the `maxBatchByteSize` then an exception will be thrown

An example use case of the new parameter is:

```java
PubsubIO.writeMessages()
    .withMaxBatchSize(100)
    .withMaxBatchByteSize(100000)
   .to("my-topic")
```